### PR TITLE
Add makefile command to attach to running container

### DIFF
--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ enter-container:
 	docker run -ti -p 5900:5900 -p 8080:6000 -v "`pwd`:/repo" --privileged --rm lkp-$(T):latest /bin/bash 
 
 attach-container:
-	docker exec -it $$(docker ps --filter ancestor=lkp-amd64 --format '{{.ID}}') /bin/bash
+	docker exec -it $$(docker ps --filter ancestor=lkp-$(T) --format '{{.ID}}') /bin/bash
 
 stop-container:
 	ps aux | grep -E 'bzImage' | grep -v grep | awk '{print $$2}' | xargs kill -9

--- a/makefile
+++ b/makefile
@@ -14,6 +14,9 @@ rebuild:
 enter-container:
 	docker run -ti -p 5900:5900 -p 8080:6000 -v "`pwd`:/repo" --privileged --rm lkp-$(T):latest /bin/bash 
 
+attach-container:
+	docker exec -it $$(docker ps --filter ancestor=lkp-amd64 --format '{{.ID}}') /bin/bash
+
 stop-container:
 	ps aux | grep -E 'bzImage' | grep -v grep | awk '{print $$2}' | xargs kill -9
 


### PR DESCRIPTION
To provide an option for those who do not use tmux (or have different keybindings like myself), this change makes it easier to connect other terminal windows to the container and manage multiplexing externally. 

Note: Stopping the first command will stop all other connections